### PR TITLE
only change /etc/hosts between control tokens

### DIFF
--- a/bin/ghost
+++ b/bin/ghost
@@ -39,7 +39,7 @@ else
         $stderr.puts "Cannot find ip for host"
         exit 3
       rescue StandardError
-        $stderr.puts "Cannot overwrite an existing entry. Use the modify subcommand"
+        $stderr.puts "Error:",$!
         exit 3
       end
     else

--- a/bin/ghost
+++ b/bin/ghost
@@ -38,9 +38,9 @@ else
       rescue SocketError
         $stderr.puts "Cannot find ip for host"
         exit 3
-      #rescue StandardError
-        #$stderr.puts "Cannot overwrite an existing entry. Use the modify subcommand"
-        #exit 3
+      rescue StandardError
+        $stderr.puts "Cannot overwrite an existing entry. Use the modify subcommand"
+        exit 3
       end
     else
       $stderr.puts "The add subcommand requires at least a hostname.\n\n"

--- a/bin/ghost
+++ b/bin/ghost
@@ -38,9 +38,9 @@ else
       rescue SocketError
         $stderr.puts "Cannot find ip for host"
         exit 3
-      rescue StandardError
-        $stderr.puts "Cannot overwrite an existing entry. Use the modify subcommand"
-        exit 3
+      #rescue StandardError
+        #$stderr.puts "Cannot overwrite an existing entry. Use the modify subcommand"
+        #exit 3
       end
     else
       $stderr.puts "The add subcommand requires at least a hostname.\n\n"

--- a/bin/ghost
+++ b/bin/ghost
@@ -16,7 +16,7 @@ def help_text(exit_code = 0)
        #{script_name} modify <hostname> <ip> OR <hostname> (will lookup ip)
        #{script_name} delete <hostname>
        #{script_name} delete_matching <pattern>
-       #{script_name} list
+       #{script_name} list [<filter>]
        #{script_name} empty
        #{script_name} export
        #{script_name} import <file>
@@ -80,7 +80,14 @@ else
       help_text 2
     end
   when 'list'
+    filter = %r|#{ARGV[1]}| if ARGV.size == 2
+    
     hosts = Host.list
+    
+    if filter
+      hosts.reject! { |host| host.name !~ filter && host.ip !~ filter }
+    end
+    
     pad = hosts.max{|a,b| a.to_s.length <=> b.to_s.length }.to_s.length
     
     puts "Listing #{hosts.size} host(s):"

--- a/ghost.gemspec
+++ b/ghost.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ghost}
-  s.version = "0.3.0"
+  s.version = "0.2.9"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bodaniel Jeanes"]
   s.autorequire = %q{ghost}
-  s.date = %q{2010-05-25}
+  s.date = %q{2011-04-15}
   s.default_executable = %q{ghost}
   s.description = %q{Allows you to create, list, and modify local hostnames}
   s.email = %q{me@bjeanes.com}

--- a/ghost.gemspec
+++ b/ghost.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ghost}
-  s.version = "0.2.8"
+  s.version = "0.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bodaniel Jeanes"]

--- a/ghost.gemspec
+++ b/ghost.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ghost}
-  s.version = "0.2.9"
+  s.version = "0.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bodaniel Jeanes"]
   s.autorequire = %q{ghost}
-  s.date = %q{2011-04-15}
+  s.date = %q{2010-05-25}
   s.default_executable = %q{ghost}
   s.description = %q{Allows you to create, list, and modify local hostnames}
   s.email = %q{me@bjeanes.com}

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -17,8 +17,7 @@ class Host
   alias :hostname :host
   
   @@hosts_file = '/etc/hosts'
-  @@permanent_hosts = [Host.new("localhost",      "127.0.0.1"),
-                       Host.new(`hostname`.chomp, "127.0.0.1")]
+
   class << self
     protected :new
     
@@ -38,7 +37,6 @@ class Host
               end
           end
       end
-      entries.delete_if { |host| @@permanent_hosts.include? host }
       entries
     end
 
@@ -94,7 +92,6 @@ class Host
     protected
 
     def write_out!(hosts)
-      hosts += @@permanent_hosts
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
 
       File.open(@@hosts_file, 'r+') do |f|

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -59,7 +59,7 @@ class Host
           
           new_host
         else
-          raise "Can not overwrite existing record"
+          raise "Can not overwrite existing record. Use the modify subcommand"
         end      
       end
     end
@@ -93,10 +93,6 @@ class Host
       end
     end
 
-    def sayho
-        puts "ho"
-    end
-
     protected
 
     def with_exclusive_file_access
@@ -123,6 +119,7 @@ class Host
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
       with_exclusive_file_access do |f|
 
+<<<<<<< HEAD
         out = ""
         over = false
         f.each do |line|
@@ -140,5 +137,33 @@ class Host
       end
    end
 
+=======
+      File.open(@@hosts_file, 'r+') do |f|
+          out,over,seen_tokens = "",false,false
+
+          f.each do |line|
+             if line =~ /^# ghost start/
+                 over,seen_tokens = true,true
+                 out << line << new_ghosts
+             elsif line =~ /^# ghost end/
+                 over = false
+             end
+
+             out << line unless over
+          end
+          if !seen_tokens 
+              out << surround_with_tokens( new_ghosts )
+          end
+
+          f.pos = 0
+          f.print out
+          f.truncate(f.pos)
+      end
+    end
+
+    def surround_with_tokens(str)
+        "\n# ghost start\n" + str + "\n# ghost end\n"
+    end
+>>>>>>> add the start/end tokens if they were not found during write_out
   end
 end

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -16,9 +16,8 @@ class Host
   alias :name :host
   alias :hostname :host
   
-  @@hosts_file = '/tmp/hosts'
-  @@permanent_hosts = [Host.new("localhost",      "127.0.0.1"),
-                       Host.new(`hostname`.chomp, "127.0.0.1")]
+  @@hosts_file = '/etc/hosts'
+
   class << self
     protected :new
     
@@ -121,7 +120,6 @@ class Host
     end
 
     def write_out!(hosts)
-      hosts += @@permanent_hosts
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
       with_exclusive_file_access do |f|
 

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -56,7 +56,7 @@ class Host
         
         new_host
       else
-        raise "Can not overwrite existing record"
+        raise "Can not overwrite existing record. Use the modify subcommand"
       end      
     end
     
@@ -85,21 +85,17 @@ class Host
       hosts
     end
 
-    def sayho
-        puts "ho"
-    end
-
     protected
 
     def write_out!(hosts)
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
 
       File.open(@@hosts_file, 'r+') do |f|
-          out = ""
-          over = false
+          out,over,seen_tokens = "",false,false
+
           f.each do |line|
              if line =~ /^# ghost start/
-                 over = true
+                 over,seen_tokens = true,true
                  out << line << new_ghosts
              elsif line =~ /^# ghost end/
                  over = false
@@ -107,10 +103,18 @@ class Host
 
              out << line unless over
           end
+          if !seen_tokens 
+              out << surround_with_tokens( new_ghosts )
+          end
+
           f.pos = 0
           f.print out
           f.truncate(f.pos)
       end
+    end
+
+    def surround_with_tokens(str)
+        "\n# ghost start\n" + str + "\n# ghost end\n"
     end
   end
 end

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -123,8 +123,6 @@ class Host
     def write_out!(hosts)
       hosts += @@permanent_hosts
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
-      puts new_ghosts
-
       with_exclusive_file_access do |f|
 
         out = ""

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -17,18 +17,20 @@ class Host
   alias :hostname :host
   
   @@hosts_file = '/etc/hosts'
+  @@start_token, @@end_token = '# ghost start', '# ghost end'
+    
 
   class << self
     protected :new
-    
+
     def list
       entries = []
       in_ghost_area = false
       File.open(@@hosts_file).each do |line|
-          if !in_ghost_area and line =~ /^# ghost start/
+          if !in_ghost_area and line =~ /^#{@@start_token}/
               in_ghost_area = true
           elsif in_ghost_area
-              if line =~ /^# ghost end/
+              if line =~ /^#{@@end_token}/o
                 in_ghost_area = false 
               elsif line =~ /^(\d+\.\d+\.\d+\.\d+)\s+(.*)$/
                   ip = $1
@@ -94,10 +96,10 @@ class Host
           out,over,seen_tokens = "",false,false
 
           f.each do |line|
-             if line =~ /^# ghost start/
+             if line =~ /^#{@@start_token}/o
                  over,seen_tokens = true,true
                  out << line << new_ghosts
-             elsif line =~ /^# ghost end/
+             elsif line =~ /^#{@@end_token}/o
                  over = false
              end
 
@@ -114,7 +116,7 @@ class Host
     end
 
     def surround_with_tokens(str)
-        "\n# ghost start\n" + str + "\n# ghost end\n"
+        "\n#{@@start_token}\n" + str + "\n#{@@end_token}\n"
     end
   end
 end

--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -96,8 +96,6 @@ class Host
     def write_out!(hosts)
       hosts += @@permanent_hosts
       new_ghosts = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
-      puts new_ghosts
-
 
       File.open(@@hosts_file, 'r+') do |f|
           out = ""

--- a/spec/etc_hosts_spec.rb
+++ b/spec/etc_hosts_spec.rb
@@ -121,8 +121,8 @@ describe Host do
     end
     
     it "should add a hostname using second hostname's ip" do
-      hostname = 'ghost-test-hostname.local'
-      alias_hostname = 'ghost-test-alias-hostname.local'
+      hostname = 'localhost.localdomain'
+      alias_hostname = 'yahoo.com'
 
       Host.empty!
 

--- a/spec/etc_hosts_spec.rb
+++ b/spec/etc_hosts_spec.rb
@@ -50,11 +50,16 @@ describe Host do
     end
     
     it "gets all hosts on a single /etc/hosts line" do
-      example = "127.0.0.1\tproject_a.local\t\t\tproject_b.local   project_c.local"
-      File.open($hosts_file, 'w') {|f| f << example}
+      example = <<-EoEx
+      127.0.0.1      localhost.localdomain
+      # ghost start
+      123.123.123.1     project_a.local\t\tproject_b.local   project_c.local
+      # ghost end
+      EoEx
+      File.open($hosts_file, 'w') {|f| f << example.gsub!(/^\s*/, '')}
       hosts = Host.list
       hosts.should have(3).items
-      hosts.map{|h|h.ip}.uniq.should == ['127.0.0.1']
+      hosts.map{|h|h.ip}.uniq.should == ['123.123.123.1']
       hosts.map{|h|h.host}.sort.should == %w[project_a.local project_b.local project_c.local]
       Host.add("project_d.local")
       Host.list.should have(4).items

--- a/spec/ghost_spec.rb
+++ b/spec/ghost_spec.rb
@@ -107,8 +107,8 @@ describe Host, ".add" do
   end
   
   it "should add a hostname using second hostname's ip" do
-    hostname = 'ghost-test-hostname.local'
-    alias_hostname = 'ghost-test-alias-hostname.local'
+    hostname = 'localhost.localdomain'
+    alias_hostname = 'yahoo.com'
     
     Host.empty!
     

--- a/spec/ghost_spec.rb
+++ b/spec/ghost_spec.rb
@@ -107,9 +107,9 @@ describe Host, ".add" do
   end
   
   it "should add a hostname using second hostname's ip" do
-    hostname = 'localhost.localdomain'
-    alias_hostname = 'yahoo.com'
-    
+    hostname = 'ghost-test-hostname.local'
+    alias_hostname = 'ghost-test-alias-hostname.local'
+
     Host.empty!
     
     Host.add(hostname)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 $TESTING=true
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'rubygems'
-require 'spec'
+#require 'spec'


### PR DESCRIPTION
I didn't want ghost to take over my whole `/etc/hosts` file because I had some custom legacy lines in there for stuff on my company's VPN, and also use another old perl script to manage a list of adservers to block, and also use the simple `noprocrast` gem to block access to sites that we shouldn't be wasting time with at work.

so, modified the Host.add and Host.write_out! methods to only change lines in between tokens in the file. If the tokens are not found on the first run, it should add them. Tests all pass.

only needed changes to the linux version since the mac one uses dscl and doesn't overwrite the whole file.
