### PR TITLE
Add flock protection to ghost

### DIFF
--- a/lib/ghost/linux-host.rb
+++ b/lib/ghost/linux-host.rb
@@ -23,37 +23,42 @@ class Host
     protected :new
     
     def list
-      entries = []
-      File.open(@@hosts_file).each do |line|
-        next if line =~ /^#/
-        if line =~ /^(\d+\.\d+\.\d+\.\d+)\s+(.*)$/
-          ip = $1
-          hosts = $2.split(/\s+/)
-          hosts.each { |host| entries << Host.new(host, ip) }
+      with_exclusive_file_access do |file|
+        entries = []
+        file.pos = 0
+        file.each do |line|
+          next if line =~ /^#/
+          if line =~ /^(\d+\.\d+\.\d+\.\d+)\s+(.*)$/
+            ip = $1
+            hosts = $2.split(/\s+/)
+            hosts.each { |host| entries << Host.new(host, ip) }
+          end
         end
+        entries.delete_if { |host| @@permanent_hosts.include? host }
+        entries
       end
-      entries.delete_if { |host| @@permanent_hosts.include? host }
-      entries
     end
 
     def add(host, ip = "127.0.0.1", force = false)
-      if find_by_host(host).nil? || force
-        delete(host)
-        
-        unless ip[/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})?$/]
-          ip = Socket.gethostbyname(ip)[3].bytes.to_a.join('.')
-        end
-        
-        new_host = Host.new(host, ip)
-        
-        hosts = list
-        hosts << new_host
-        write_out!(hosts)
-        
-        new_host
-      else
-        raise "Can not overwrite existing record"
-      end      
+      with_exclusive_file_access do
+        if find_by_host(host).nil? || force
+          delete(host)
+          
+          unless ip[/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})?$/]
+            ip = Socket.gethostbyname(ip)[3].bytes.to_a.join('.')
+          end
+          
+          new_host = Host.new(host, ip)
+          
+          hosts = list
+          hosts << new_host
+          write_out!(hosts)
+          
+          new_host
+        else
+          raise "Can not overwrite existing record"
+        end      
+      end
     end
     
     def find_by_host(hostname)
@@ -69,24 +74,52 @@ class Host
     end
     
     def delete(name)
-      hosts = list
-      hosts = hosts.delete_if { |host| host.name == name }
-      write_out!(hosts)
+      with_exclusive_file_access do
+        hosts = list
+        hosts = hosts.delete_if { |host| host.name == name }
+        write_out!(hosts)
+      end
     end
     
     def delete_matching(pattern)
-      pattern = Regexp.escape(pattern)
-      hosts = list.select { |host| host.name.match(/#{pattern}/) }
-      hosts.each { |host| delete(host.name) }
-      hosts
+      with_exclusive_file_access do
+        pattern = Regexp.escape(pattern)
+        hosts = list.select { |host| host.name.match(/#{pattern}/) }
+        hosts.each { |host| delete(host.name) }
+        hosts
+      end
     end
 
     protected
 
+    def with_exclusive_file_access
+      return_val = nil
+
+      if @_file
+        return_val = yield @_file
+      else
+        File.open(@@hosts_file, 'r+') do |f|
+          f.flock File::LOCK_EX
+          begin
+            @_file = f
+            return_val = yield f
+          ensure
+            @_file = nil
+          end
+        end
+      end
+
+      return_val
+    end
+
     def write_out!(hosts)
-      hosts += @@permanent_hosts
-      output = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
-      File.open(@@hosts_file, 'w') {|f| f.print output }
+      with_exclusive_file_access do |f|
+        hosts += @@permanent_hosts
+        output = hosts.inject("") {|s, h| s + "#{h.ip} #{h.hostname}\n" }
+        f.pos = 0
+        f.print output
+        f.truncate(f.pos)
+      end
     end
   end
 end


### PR DESCRIPTION
We use ghost to setup test hostnames for some integration tests. On our CI server when multiple builds are running simultaneously we get random failures due to races on reading/writing the hosts file. This commit adds exclusive locking for reads/writes to ensure updates (from ghost and anything else that uses flock properly) to the hosts file are effectively atomic.
