### PR TITLE
Ghost import can now fetch files over the wire

### DIFF
--- a/bin/ghost
+++ b/bin/ghost
@@ -9,6 +9,7 @@ rescue LoadError
   # no rubygems to load, so we fail silently
 end
 require 'ghost'
+require 'open-uri'
 
 def help_text(exit_code = 0)
   script_name = File.basename $0
@@ -110,7 +111,8 @@ else
   when 'import'
     if ARGV.size == 2
       begin
-        File.foreach(ARGV[1]) do |line|
+        import_file = open(ARGV[1])
+        import_file.each_line do |line|
           host_infos = line.strip.split(' ', 2)
           host = Host.add(*host_infos)
           puts "  [Adding] #{host.name} -> #{host.ip}"


### PR DESCRIPTION
I did a small change in bin/ghost so it can fetch and import files over http connections.

At work, we want to share the host setups between a few developers and I thought that adding this to ghost would be better than just writting a wrap-up script that fetches the file and then uses ghost to register hostnames.

I simply split the `File.foreach` inside bin/ghost to open and the iter over the file. Using open-uri gem, `#open` becomes smart enough to handle files and fetches.

Hope this is useful.
