### PR TITLE
Fix for issue #14 in bjeanes/ghost

### DIFF
--- a/lib/ghost.rb
+++ b/lib/ghost.rb
@@ -2,7 +2,13 @@ $: << File.dirname(__FILE__)
 
 case RUBY_PLATFORM
 when /darwin/
-  require 'ghost/mac-host'
+  productVersion = `/usr/bin/sw_vers -productVersion`.strip
+  end
+  if productVersion =~ /^10\.7\.[2-9]{1}$/
+    require 'ghost/linux-host'
+  else
+    require 'ghost/mac-host'
+  end
 when /linux/
   require 'ghost/linux-host'
 end

--- a/lib/ghost.rb
+++ b/lib/ghost.rb
@@ -3,7 +3,6 @@ $: << File.dirname(__FILE__)
 case RUBY_PLATFORM
 when /darwin/
   productVersion = `/usr/bin/sw_vers -productVersion`.strip
-  end
   if productVersion =~ /^10\.7\.[2-9]{1}$/
     require 'ghost/linux-host'
   else


### PR DESCRIPTION
Fix for issue #14 in bjeanes/ghost
Looks up Mac OS X Version and uses /etc/hosts if equal or greater than 10.7.2
