### PR TITLE
Fix for issue #14 version checking on Mountain Lion.

### DIFF
--- a/lib/ghost.rb
+++ b/lib/ghost.rb
@@ -9,8 +9,9 @@ require 'rbconfig'
 
 case RbConfig::CONFIG['host_os']
 when /darwin/
-  productVersion = `/usr/bin/sw_vers -productVersion`.strip
-  if productVersion =~ /^10\.7\.[2-9]{1}$/
+  sw_vers = `/usr/bin/sw_vers -productVersion`.strip
+  # use linux-style hosts on Mac OS X Lion and Mountain Lion
+  if sw_vers =~ /^10\.7\.[2-9]$/ or sw_vers =~ /^10\.8(\.[0-9])?$/
     require 'ghost/linux-host'
   else
     require 'ghost/mac-host'


### PR DESCRIPTION
Uses /etc/hosts if equal or greater than 10.8.

I just updated the regular expression if statement to detect 10.8 and, in the future, 10.8.1, 10.8.2, etc.
