### PR TITLE
Pass dscl create errors up to the ghost user

### DIFF
--- a/lib/ghost/mac-host.rb
+++ b/lib/ghost/mac-host.rb
@@ -22,9 +22,14 @@ module Ghost
             ip = Socket.gethostbyname(ip)[3].bytes.to_a.join('.')
           end
 
-          `#{CreateCmd % [host, ip]}`
-          flush!
-          find_by_host(host)
+          # command returns empty iff success
+          errorMessage = `#{CreateCmd % [host, ip]}`
+          if errorMessage
+            raise RuntimeError, "Ghost failed due to dscl error %s" % errorMessage
+          else                    
+            flush!
+            find_by_host(host)
+          end
         else
           raise Ghost::RecordExists, "Can not overwrite existing record"
         end


### PR DESCRIPTION
Currently when the `create` command fails, the `add()` function simply returns nil and the user never sees the error. They just get a confusing `undefined method "name" error` exception as in issue #28.

This patch raises an error with the `dscl` output as its message.
