### PR TITLE
Introduce support for different operating systems.

### DIFF
--- a/lib/ghost/store/hosts_file_store.rb
+++ b/lib/ghost/store/hosts_file_store.rb
@@ -2,6 +2,7 @@ require 'set'
 
 require 'ghost/host'
 require 'ghost/tokenized_file'
+require 'resolv'
 
 module Ghost
   module Store
@@ -10,11 +11,7 @@ module Ghost
     class HostsFileStore
       attr_accessor :path, :file
 
-      # TODO: Support windows locations:
-      #   Windows 95/98/Me  c:\windows\hosts
-      #   Windows NT/2000/XP Pro  c:\winnt\system32\drivers\etc\hosts
-      #   Windows XP Home c:\windows\system32\drivers\etc\hosts
-      def initialize(path = "/etc/hosts")
+      def initialize(path = Resolv::Hosts::DefaultFileName)
         self.path = path
         self.file = Ghost::TokenizedFile.new(path, "# ghost start", "# ghost end")
       end

--- a/spec/ghost/store/hosts_file_store_spec.rb
+++ b/spec/ghost/store/hosts_file_store_spec.rb
@@ -34,7 +34,10 @@ describe Ghost::Store::HostsFileStore do
   before { write(contents) }
 
   it 'manages the default file of /etc/hosts when no file path is provided' do
-    described_class.new.path.should == "/etc/hosts"
+		previous_hosts_location = Resolv::Hosts::DefaultFileName
+		Resolv::Hosts::DefaultFileName = "hosts_location"
+    described_class.new.path.should == "hosts_location"
+		Resolv::Hosts::DefaultFileName = previous_hosts_location
   end
 
   it 'manages the file at the provided path when given' do


### PR DESCRIPTION
By using 'Resolv::Hosts::DefaultFileName' instead of using
hard-coded '/etc/hosts' we support all operating systems.
Mainly introduced to support Windows OS.
